### PR TITLE
Set "kexec-tools" translation domain for the spoke

### DIFF
--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -39,6 +39,7 @@ class KdumpSpoke(NormalSpoke):
     builderObjects = ["KdumpWindow", "advancedConfigBuffer"]
     mainWidgetName = "KdumpWindow"
     uiFile = "kdump.glade"
+    translationDomain = "kexec-tools"
 
     icon = "computer-fail-symbolic"
     title = N_("_KDUMP")


### PR DESCRIPTION
The Spoke classes imported from Anaconda by default use the "anaconda" translation domain. 
If a different domain should be used (such as the "kexec-tools" one) it needs to be set with the translationDomain class attribute.
