### PR TITLE
Use blivet.arch.getArch() to get current arch

### DIFF
--- a/com_redhat_kdump/common.py
+++ b/com_redhat_kdump/common.py
@@ -21,8 +21,9 @@
 import os
 __all__ = ["getReservedMemory", "getTotalMemory", "getMemoryBounds", "getOS"]
 
+import blivet.arch
+
 from pyanaconda.isys import total_memory
-from pyanaconda.flags import flags
 from com_redhat_kdump.constants import OS_RELEASE
 
 _reservedMemory = None
@@ -62,7 +63,7 @@ def getMemoryBounds():
 
     totalMemory = getTotalMemory()
 
-    if flags.targetarch == 'ppc64':
+    if blivet.arch.getArch() == 'ppc64':
         lowerBound = 256
         minUsable = 1024
         step = 1


### PR DESCRIPTION
The targetarch flag & accompanying boot option have been recently dropped by Anaconda as the flag was no longer being used by Anaconda code and the boot option was no longer supplied by the tools that use Anaconda.

Also unlike targetarch that depended on the the target architecture being set on boot command line, blivet.arch.getArch() returns the actual architecture of the current environment. So getArch() will actually work in a ppc64 environment without any special boot options, unlike targetarch.
