### PR TITLE
Call kdumpctl setup-crypttab so kdump will work on boot for encrypted dump target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,21 @@
-name: kdump-anaconda
+name: kdump-anaconda-addon tests
 
 on: pull_request
 
 jobs:
   lint-check:
     runs-on: ubuntu-latest
-    container: ghcr.io/coiby/kdump_anaconda:f38
+    container: docker.io/fedora:latest
     steps:
-      - uses: actions/checkout@v2
-      - run: make runpylint
+      - name: Install dependent packages for tests
+        run: dnf install anaconda python-pytest python-blivet pylint make -yq
 
-  unit-tests:
-    runs-on: ubuntu-latest
-    container: ghcr.io/coiby/kdump_anaconda:f38
-    steps:
-      - uses: actions/checkout@v2
-      - run: make unittest
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: lint check
+        run: make runpylint
+
+      - name: unit tests
+        run: make unittest
+

--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -31,6 +31,7 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.utils import fancy_set_sensitive
 from pyanaconda.ui.communication import hubQ
+import blivet.arch
 
 from com_redhat_kdump.i18n import _, N_
 from com_redhat_kdump.constants import FADUMP_CAPABLE_FILE, KDUMP, ENCRYPTION_WARNING
@@ -135,7 +136,7 @@ class KdumpSpoke(NormalSpoke):
         self._enableButton.emit("toggled")
 
         self.clear_info()
-        if self._luks_devs:
+        if self._luks_devs and blivet.arch.get_arch() != "x86_64":
             self.set_warning(_(ENCRYPTION_WARNING))
 
     def apply(self):

--- a/com_redhat_kdump/service/installation.py
+++ b/com_redhat_kdump/service/installation.py
@@ -17,7 +17,6 @@
 #
 import logging
 import os
-import shutil
 
 from pyanaconda.core import util
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
@@ -143,7 +142,7 @@ class KdumpInstallationTask(Task):
         # Anaconda may be used to create minimal container image which doesn't
         # have systemd installed
         # https://issues.redhat.com/browse/RHEL-41082?focusedId=26969576&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26969576
-        if not shutil.which(self._sysroot + "/systemctl"):
+        if not os.path.exists(self._sysroot + "/usr/bin/systemctl"):
             log.debug("systemd not installed, skip KdumpInstallationTask")
             return
 

--- a/com_redhat_kdump/service/installation.py
+++ b/com_redhat_kdump/service/installation.py
@@ -29,7 +29,7 @@ from com_redhat_kdump.common import getLuksDevices
 
 log = logging.getLogger(__name__)
 
-__all__ = ["KdumpBootloaderConfigurationTask", "KdumpInstallationTask"]
+__all__ = ["KdumpBootloaderConfigurationTask", "KdumpInstallationTask", "KdumpCrypttabSetupTask"]
 
 
 class KdumpBootloaderConfigurationTask(Task):
@@ -156,3 +156,40 @@ class KdumpInstallationTask(Task):
             [systemctl_action, "kdump.service"],
             root=self._sysroot
         )
+
+
+class KdumpCrypttabSetupTask(Task):
+    """The task for setting up crypttab for kdump."""
+
+    def __init__(self, sysroot):
+        """Create a task."""
+        super().__init__()
+        self._sysroot = sysroot
+
+    @property
+    def name(self):
+        return "Setup crypttab for kdump"
+
+    def _has_setup_crypttab_command(self):
+        """Check if kdumpctl has setup-crypttab subcommand by checking help output."""
+        try:
+            help_output = util.execWithCapture("kdumpctl", ["help"], root=self._sysroot)
+            return "setup-crypttab" in help_output
+        except FileNotFoundError:
+            log.debug("kdumpctl command not found")
+            return False
+        except Exception as e:
+            log.warning("Failed to check kdumpctl help: %s", e)
+            return False
+
+    def run(self):
+        """Run the task."""
+        if not self._has_setup_crypttab_command():
+            log.debug("kdumpctl setup-crypttab command not available, skipping")
+            return
+
+        try:
+            util.execWithRedirect("kdumpctl", ["setup-crypttab"], root=self._sysroot)
+            log.debug("Successfully executed kdumpctl setup-crypttab")
+        except Exception as e:
+            log.warning("Failed to execute kdumpctl setup-crypttab: %s", e)

--- a/com_redhat_kdump/service/kdump.py
+++ b/com_redhat_kdump/service/kdump.py
@@ -26,7 +26,7 @@ from pyanaconda.modules.common.structures.requirement import Requirement
 
 from com_redhat_kdump.common import getMemoryBounds
 from com_redhat_kdump.constants import KDUMP
-from com_redhat_kdump.service.installation import KdumpBootloaderConfigurationTask, KdumpInstallationTask
+from com_redhat_kdump.service.installation import KdumpBootloaderConfigurationTask, KdumpInstallationTask, KdumpCrypttabSetupTask
 from com_redhat_kdump.service.kdump_interface import KdumpInterface
 from com_redhat_kdump.service.kickstart import KdumpKickstartSpecification
 
@@ -137,12 +137,21 @@ class KdumpService(KickstartService):
 
         :return: a list of tasks
         """
-        return [
+        tasks = [
             KdumpInstallationTask(
                 sysroot=conf.target.system_root,
                 kdump_enabled=self.kdump_enabled,
             )
         ]
+
+        if self.kdump_enabled:
+            tasks.append(
+                KdumpCrypttabSetupTask(
+                    sysroot=conf.target.system_root
+                )
+            )
+
+        return tasks
 
     def configure_bootloader_with_tasks(self, kernels):
         return [

--- a/com_redhat_kdump/service/kdump.py
+++ b/com_redhat_kdump/service/kdump.py
@@ -29,6 +29,7 @@ from com_redhat_kdump.constants import KDUMP
 from com_redhat_kdump.service.installation import KdumpBootloaderConfigurationTask, KdumpInstallationTask, KdumpCrypttabSetupTask
 from com_redhat_kdump.service.kdump_interface import KdumpInterface
 from com_redhat_kdump.service.kickstart import KdumpKickstartSpecification
+import blivet.arch
 
 log = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class KdumpService(KickstartService):
             )
         ]
 
-        if self.kdump_enabled:
+        if self.kdump_enabled and blivet.arch.get_arch() == "x86_64":
             tasks.append(
                 KdumpCrypttabSetupTask(
                     sysroot=conf.target.system_root

--- a/test/unit_tests/test_installation.py
+++ b/test/unit_tests/test_installation.py
@@ -181,9 +181,9 @@ class KdumpInstallationTestCase(TestCase):
         assert mock_exec.call_count == 2
 
     @patch("com_redhat_kdump.service.installation.util")
-    @patch("shutil.which")
-    def test_installation_kdump_disabled(self, mock_shutil, mock_util):
-        mock_shutil.return_value = True
+    @patch("os.path.exists")
+    def test_installation_kdump_disabled(self, mock_os_path, mock_util):
+        mock_os_path.return_value = True
         task = KdumpInstallationTask(
             sysroot="/mnt/sysroot",
             kdump_enabled=False
@@ -196,9 +196,9 @@ class KdumpInstallationTestCase(TestCase):
         )
 
     @patch("com_redhat_kdump.service.installation.util")
-    @patch("shutil.which")
-    def test_installation_kdump_enabled(self, mock_shutil, mock_util):
-        mock_shutil.return_value = True
+    @patch("os.path.exists")
+    def test_installation_kdump_enabled(self, mock_os_path, mock_util):
+        mock_os_path.return_value = True
         task = KdumpInstallationTask(
             sysroot="/mnt/sysroot",
             kdump_enabled=True
@@ -211,9 +211,9 @@ class KdumpInstallationTestCase(TestCase):
         )
 
     @patch("com_redhat_kdump.service.installation.util")
-    @patch("shutil.which")
-    def test_installation_kdump_disable_no_systemctl(self, mock_shutil, mock_util):
-        mock_shutil.return_value = False
+    @patch("os.path.exists")
+    def test_installation_kdump_disable_no_systemctl(self, mock_os_path, mock_util):
+        mock_os_path.return_value = False
         task = KdumpInstallationTask(
             sysroot="/mnt/sysroot",
             kdump_enabled=False

--- a/test/unit_tests/test_installation.py
+++ b/test/unit_tests/test_installation.py
@@ -1,7 +1,7 @@
 from unittest.case import TestCase
 from unittest.mock import patch
 from com_redhat_kdump.constants import FADUMP_CAPABLE_FILE
-from com_redhat_kdump.service.installation import KdumpBootloaderConfigurationTask, KdumpInstallationTask
+from com_redhat_kdump.service.installation import KdumpBootloaderConfigurationTask, KdumpInstallationTask, KdumpCrypttabSetupTask
 
 SYSROOT = "/sysroot"
 
@@ -220,3 +220,55 @@ class KdumpInstallationTestCase(TestCase):
         )
         task.run()
         mock_util.execWithRedirect.assert_not_called()
+
+    @patch("pyanaconda.core.util.execWithCapture")
+    def test_crypttab_setup_check_help_with_setup_crypttab(self, mock_exec):
+        mock_exec.return_value = "setup-crypttab   Setup crypttab for kdump"
+        task = KdumpCrypttabSetupTask(sysroot="/mnt/sysroot")
+        result = task._has_setup_crypttab_command()
+        mock_exec.assert_called_once_with("kdumpctl", ["help"], root="/mnt/sysroot")
+        assert result is True
+
+    @patch("pyanaconda.core.util.execWithCapture")
+    def test_crypttab_setup_check_help_without_setup_crypttab(self, mock_exec):
+        mock_exec.return_value = "start   Start kdump\nstop    Stop kdump"
+        task = KdumpCrypttabSetupTask(sysroot="/mnt/sysroot")
+        result = task._has_setup_crypttab_command()
+        mock_exec.assert_called_once_with("kdumpctl", ["help"], root="/mnt/sysroot")
+        assert result is False
+
+    @patch("pyanaconda.core.util.execWithCapture")
+    def test_crypttab_setup_check_help_kdumpctl_not_found(self, mock_exec):
+        mock_exec.side_effect = FileNotFoundError()
+        task = KdumpCrypttabSetupTask(sysroot="/mnt/sysroot")
+        result = task._has_setup_crypttab_command()
+        mock_exec.assert_called_once_with("kdumpctl", ["help"], root="/mnt/sysroot")
+        assert result is False
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    @patch("com_redhat_kdump.service.installation.KdumpCrypttabSetupTask._has_setup_crypttab_command")
+    def test_crypttab_setup_run_with_command_available(self, mock_has_command, mock_exec):
+        mock_has_command.return_value = True
+        task = KdumpCrypttabSetupTask(sysroot="/mnt/sysroot")
+        task.run()
+        mock_has_command.assert_called_once()
+        mock_exec.assert_called_once_with("kdumpctl", ["setup-crypttab"], root="/mnt/sysroot")
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    @patch("com_redhat_kdump.service.installation.KdumpCrypttabSetupTask._has_setup_crypttab_command")
+    def test_crypttab_setup_run_without_command_available(self, mock_has_command, mock_exec):
+        mock_has_command.return_value = False
+        task = KdumpCrypttabSetupTask(sysroot="/mnt/sysroot")
+        task.run()
+        mock_has_command.assert_called_once()
+        mock_exec.assert_not_called()
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    @patch("com_redhat_kdump.service.installation.KdumpCrypttabSetupTask._has_setup_crypttab_command")
+    def test_crypttab_setup_run_execution_failure(self, mock_has_command, mock_exec):
+        mock_has_command.return_value = True
+        mock_exec.side_effect = Exception("Command failed")
+        task = KdumpCrypttabSetupTask(sysroot="/mnt/sysroot")
+        task.run()
+        mock_has_command.assert_called_once()
+        mock_exec.assert_called_once_with("kdumpctl", ["setup-crypttab"], root="/mnt/sysroot")


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-29039

Call "kdumpctl setup-crypttab" to set up /etc/crypttab so the volume
keys can be passed to the crash kernel.

Note Anaconda writes to /etc/crypttab at "Early storage configuration"
phase. So we set up /etc/crypttab at "Anaconda addon configuration"
phase which happens before Anaconda generates initramfs. So the updated
crypttab will be built into the initramfs.

    01:52:19,877 INF installation: Queue started: Early storage configuration (3/18)
    ...
    ...
    01:56:17,041 INF installation: Queue started: Anaconda addon configuration (15/18)
    01:56:17,044 INF installation: Queue started: Initramfs generation (16/18)
